### PR TITLE
Make oauth backend dotenv dependent

### DIFF
--- a/project/common_settings.py
+++ b/project/common_settings.py
@@ -53,7 +53,6 @@ LOGIN_REDIRECT_URL = reverse_lazy('home')
 # https://docs.djangoproject.com/en/1.11/ref/settings/#authentication-backends
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    #'oauth.authbackend.OAuthBackend',
 ]
 
 
@@ -82,7 +81,6 @@ INSTALLED_APPS = [
 
     'project.utils',
     'appname',
-    #'oauth',
 ]
 
 MIDDLEWARE = [
@@ -187,9 +185,9 @@ GOOGLE_ANALYTICS_KEY = env('GOOGLE_ANALYTICS_KEY')
 # https://SERVER/oauth/provider/google/complete
 if env('GOOGLE_OPENIDCONNECT_KEY'):
     GOOGLE_OPENIDCONNECT_KEY = env('GOOGLE_OPENIDCONNECT_KEY')
-
     GOOGLE_OPENIDCONNECT_SECRET = env('GOOGLE_OPENIDCONNECT_SECRET')
 
+    AUTHENTICATION_BACKENDS.append('oauth.authbackend.OAuthBackend')
     INSTALLED_APPS.append('oauth')
 
 


### PR DESCRIPTION
Makes the optional oauth backend dependent on the dotenv. This is consistent with the sentry/raven config.